### PR TITLE
Issue #681 by cableman: Added new pincode length (6 chars)

### DIFF
--- a/ding_user.module
+++ b/ding_user.module
@@ -214,6 +214,7 @@ function ding_user_form_user_admin_settings_alter(&$form, &$form_state, $form_id
     '#options' => array(
       4 => t('Max @number chars', array('@number' => 4)),
       5 => t('Max @number chars', array('@number' => 5)),
+      6 => t('Max @number chars', array('@number' => 6)),
     ),
     '#default_value' => ding_user_get_pincode_length(),
   );


### PR DESCRIPTION
Some libraries are now using 6 char in pin-code length. This PR adds that extra option.

See http://platform.dandigbib.org/issues/681