### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_user.make
+++ b/ding_user.make
@@ -26,7 +26,7 @@ projects[profile2][subdir] = "contrib"
 projects[profile2][version] = "1.3"
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[entity][subdir] = "contrib"
 projects[entity][version] = "1.5"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.