### PR TITLE
Fix redirect loop on /user by moving redirect to hook_init().

### DIFF
--- a/ding_user.module
+++ b/ding_user.module
@@ -7,9 +7,9 @@
 include_once 'ding_user_comments.inc';
 
 /**
- * Implements hook_preprocess_html().
+ * Implements hook_init().
  */
-function ding_user_preprocess_html(&$variables) {
+function ding_user_init() {
   $args = arg();
   if ($args[0] == 'user') {
     // Set default title.


### PR DESCRIPTION
Hitting /user results in a redirect loop. It seems that something manages to do "/user", which makes drupal_goto() use the destination rather than the given path.

Rather than trying to fiddle with the destination, it makes more sense to move the redirection (and cache headers) to hook_init() rather than hook_preprocess_html() (which was an odd choice anyway).
